### PR TITLE
fix L2 links in drop down menu

### DIFF
--- a/site/.vitepress/config.mjs
+++ b/site/.vitepress/config.mjs
@@ -58,10 +58,10 @@ export default defineConfig({
           {
             text: 'Lightning 2',
             items: [
-              { text: 'Lightning Core', link: '/docs/#/lightning-core-reference', target: '_blank' },
-              { text: 'Lightning SDK', link: '/docs/#/lightning-sdk-reference', target: '_blank' },
-              { text: 'Lightning CLI', link: '/docs/#/lightning-cli-reference', target: '_blank' },
-              { text: 'Lightning UI', link: '/docs/#/lightning-ui-reference', target: '_blank' },
+              { text: 'Lightning Core', link: '/docs/#/lightning-core-reference/index', target: '_blank' },
+              { text: 'Lightning SDK', link: '/docs/#/lightning-sdk-reference/index', target: '_blank' },
+              { text: 'Lightning CLI', link: '/docs/#/lightning-cli-reference/index', target: '_blank' },
+              { text: 'Lightning UI', link: '/docs/#/lightning-ui-reference/index', target: '_blank' },
             ]
           },
           {


### PR DESCRIPTION
Current links for L2 in dropdown menu landed on a 404, this fix points them to the index of each reference.